### PR TITLE
Add Admin Clock addon for WHMCS

### DIFF
--- a/modules/addons/admin_clock/admin_clock.php
+++ b/modules/addons/admin_clock/admin_clock.php
@@ -1,0 +1,172 @@
+<?php
+if (!defined("WHMCS")) {
+    die("This file cannot be accessed directly");
+}
+
+function admin_clock_config()
+{
+    return [
+        'name' => 'Admin Clock',
+        'description' => 'Displays current server time in the WHMCS admin area.',
+        'version' => '1.0',
+        'author' => 'Code-Alpha',
+        'fields' => []
+    ];
+}
+
+function admin_clock_activate()
+{
+    return [
+        'status' => 'success',
+        'description' => 'Admin Clock Activated'
+    ];
+}
+
+function admin_clock_deactivate()
+{
+    return [
+        'status' => 'success',
+        'description' => 'Admin Clock Deactivated'
+    ];
+}
+
+use WHMCS\Database\Capsule;
+
+/**
+ * Calculate active time in seconds for each admin between $start and $end
+ * using data from tbladminlog. This function performs read-only queries.
+ *
+ * @param string $start MySQL datetime
+ * @param string $end   MySQL datetime
+ * @return array        [adminId => seconds]
+ */
+function admin_clock_get_activity($start, $end)
+{
+    $log = Capsule::table('tbladminlog')
+        ->where('logintime', '>=', $start)
+        ->where('logintime', '<=', $end);
+
+    $schema = Capsule::schema();
+    if ($schema->hasColumn('tbladminlog', 'adminusername')) {
+        $records = $log->get(['adminusername', 'logintime', 'logouttime', 'lastvisit']);
+        $admins = Capsule::table('tbladmins')->pluck('id', 'username');
+        $getAdminId = function ($row) use ($admins) {
+            return $admins[$row->adminusername] ?? null;
+        };
+    } else {
+        $idColumn = $schema->hasColumn('tbladminlog', 'adminid') ? 'adminid' : 'admin_id';
+        $records = $log->get([$idColumn, 'logintime', 'logouttime', 'lastvisit']);
+        $getAdminId = function ($row) use ($idColumn) {
+            return $row->$idColumn ?? null;
+        };
+    }
+
+    $activity = [];
+    foreach ($records as $row) {
+        $adminId = $getAdminId($row);
+        if (!$adminId) {
+            continue;
+        }
+        $login  = strtotime($row->logintime);
+        $logout = $row->logouttime ? strtotime($row->logouttime)
+                 : ($row->lastvisit ? strtotime($row->lastvisit) : $login);
+        $seconds = max(0, $logout - $login);
+        if (!isset($activity[$adminId])) {
+            $activity[$adminId] = 0;
+        }
+        $activity[$adminId] += $seconds;
+    }
+
+    return $activity;
+}
+
+/**
+ * Count ticket replies made by admins between $start and $end
+ *
+ * @param string $start MySQL datetime
+ * @param string $end   MySQL datetime
+ * @return array        [adminId => count]
+ */
+function admin_clock_get_ticket_replies($start, $end)
+{
+    $schema = Capsule::schema();
+    $field = $schema->hasColumn('tblticketreplies', 'admin') ? 'admin' : 'adminid';
+
+    $records = Capsule::table('tblticketreplies')
+        ->where('date', '>=', $start)
+        ->where('date', '<=', $end)
+        ->where($field, '!=', '')
+        ->select($field, Capsule::raw('COUNT(*) as total'))
+        ->groupBy($field)
+        ->get();
+
+    if ($field === 'admin') {
+        $map = Capsule::table('tbladmins')->pluck('id', 'username');
+    } else {
+        $map = Capsule::table('tbladmins')->pluck('id', 'id');
+    }
+
+    $counts = [];
+    foreach ($records as $row) {
+        $key = $row->$field;
+        if (!isset($map[$key])) {
+            continue;
+        }
+        $adminId = $map[$key];
+        $counts[$adminId] = (int) $row->total;
+    }
+
+    return $counts;
+}
+
+/**
+ * Render the Admin Clock output page
+ */
+function admin_clock_output($vars)
+{
+    $now = time();
+    $timeframes = [
+        'last24h'  => ['label' => 'Last 24 Hours', 'start' => $now - 86400],
+        'today'    => ['label' => 'Today',        'start' => strtotime('today')],
+        'last7d'   => ['label' => 'Last 7 Days',   'start' => $now - 7 * 86400],
+        'thisweek' => ['label' => 'This Week',     'start' => strtotime('monday this week')],
+        'last30d'  => ['label' => 'Last 30 Days',  'start' => $now - 30 * 86400],
+        'thismonth'=> ['label' => 'This Month',    'start' => strtotime(date('Y-m-01 00:00:00'))],
+        'last365d' => ['label' => 'Last 365 Days', 'start' => $now - 365 * 86400],
+        'thisyear' => ['label' => 'This Year',     'start' => strtotime(date('Y-01-01 00:00:00'))],
+    ];
+
+    $admins = Capsule::table('tbladmins')->get(['id', 'firstname', 'lastname', 'username']);
+
+    $activityData = [];
+    $ticketData   = [];
+    foreach ($timeframes as $key => $frame) {
+        $start = date('Y-m-d H:i:s', $frame['start']);
+        $end   = date('Y-m-d H:i:s', $now);
+        $activityData[$key] = admin_clock_get_activity($start, $end);
+        $ticketData[$key]   = admin_clock_get_ticket_replies($start, $end);
+    }
+
+    $display = [];
+    foreach ($admins as $admin) {
+        foreach ($timeframes as $key => $frame) {
+            $seconds = $activityData[$key][$admin->id] ?? 0;
+            $timeStr = gmdate('H:i:s', $seconds);
+            $replies = $ticketData[$key][$admin->id] ?? 0;
+            $display[$admin->id][$key] = $timeStr . ' / ' . $replies;
+        }
+    }
+
+    return [
+        'pagetitle'   => 'Admin Clock',
+        'templatefile'=> 'activity',
+        'requirelogin'=> true,
+        'vars'        => [
+            'timeframes' => $timeframes,
+            'admins'     => $admins,
+            'display'    => $display,
+            'currentTime'=> date('Y-m-d H:i:s'),
+        ]
+    ];
+}
+?>

--- a/modules/addons/admin_clock/hooks.php
+++ b/modules/addons/admin_clock/hooks.php
@@ -1,0 +1,17 @@
+<?php
+if (!defined("WHMCS")) {
+    die("This file cannot be accessed directly");
+}
+
+function admin_clock_widget($vars)
+{
+    $time  = date('Y-m-d H:i:s');
+    $title = 'Server Clock';
+    $link  = 'addonmodules.php?module=admin_clock';
+    $content  = '<div style="text-align:center;font-size:18px;"><strong>' . $time . '</strong></div>';
+    $content .= '<div class="text-center" style="margin-top:5px;"><a href="' . $link . '" class="btn btn-sm btn-default">View Admin Activity</a></div>';
+    return ['title' => $title, 'content' => $content];
+}
+
+add_hook('AdminHomeWidgets', 1, 'admin_clock_widget');
+?>

--- a/modules/addons/admin_clock/lang/english.php
+++ b/modules/addons/admin_clock/lang/english.php
@@ -1,0 +1,5 @@
+<?php
+$_ADDONLANG['current_time'] = 'Current server time:';
+$_ADDONLANG['admin_activity'] = 'Admin Activity';
+$_ADDONLANG['replies'] = 'replies';
+?>

--- a/modules/addons/admin_clock/templates/activity.tpl
+++ b/modules/addons/admin_clock/templates/activity.tpl
@@ -1,0 +1,21 @@
+<table class="table table-striped" style="min-width:800px;">
+    <thead>
+        <tr>
+            <th>Admin</th>
+            {foreach from=$timeframes item=frame key=key}
+                <th>{$frame.label}</th>
+            {/foreach}
+        </tr>
+    </thead>
+    <tbody>
+    {foreach from=$admins item=admin}
+        <tr>
+            <td>{$admin.username|escape}</td>
+            {foreach from=$timeframes key=tf item=frame}
+                <td>{$display[$admin.id][$tf]|escape} {$LANG.replies}</td>
+            {/foreach}
+        </tr>
+    {/foreach}
+    </tbody>
+</table>
+<div class="text-center text-muted">{$LANG.current_time} {$currentTime}</div>


### PR DESCRIPTION
## Summary
- create `modules/addons/admin_clock` addon
- provide module file with config & output
- add widget hook to show current server time
- include English language file
- add admin activity tracking by timeframe
- add Smarty template and ticket reply counts
- fix admin activity queries for username column
- handle schema variations for admin identifiers

## Testing
- `php -l modules/addons/admin_clock/admin_clock.php`
- `php -l modules/addons/admin_clock/hooks.php`
- `php -l modules/addons/admin_clock/lang/english.php`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688914737d5c8330b49c84bad1947c54